### PR TITLE
Receive sysex merge

### DIFF
--- a/script/synthmata.js
+++ b/script/synthmata.js
@@ -56,6 +56,8 @@ function onMIDIFailure(msg) {
 function onMidiMessage(evt) {
     var data    = evt.data;
     if(data[0]!=0xF0)  return;  // only handle SYSEX messages
+    var channel=data[2] & 0xf;
+    if(channel != selectedMidiChannel) return;
     if(!validateSysexData(data)) return;
     loadSysex(data);
     console.log("SYSEX received!");
@@ -468,8 +470,8 @@ function validateSysexData(data) {
         console.log("doesn't end with EOX");
         return false; // doesn't end with EOX
     }
-    if (data[2] & 0x70 != 0) {
-        console.log("sub status is not correct");
+    if ((data[2] & 0x70) != 0) {
+        console.log("sub status is not correct:");
         return false; // sub status is not correct
     }
     if (data[3] != 0) {

--- a/volca-fm/index.html
+++ b/volca-fm/index.html
@@ -212,7 +212,7 @@
                     </div>
                     <div class="controller">
                         <label for="sysex115">Level Scale Right Depth </label>
-                        <input class="sysexParameter" data-sysexparameterno="115" data-displayvaluefunc="addOne" id="sysex115" max="99" min="0" type="range" />
+                        <input class="sysexParameter" data-sysexparameterno="115" id="sysex115" max="99" min="0" type="range" />
                     </div>
                     <div class="controller">
                         <label for="sysex116">Level Scale Left Curve </label>

--- a/volca-fm/index.html
+++ b/volca-fm/index.html
@@ -116,6 +116,7 @@
                 <div class="controlitemgroup" id="midiSetup">
                     <h3>Midi Device Setup</h3>
                     <p>NB For Volca-FM please leave channel set to '1' as the Volca only listens for patch information on this channel</p>
+                    <p>For Yamaha DX7, leave channel set to '1' if you want to receive voices from the DX7 ('Sysex available' mode), as it always transmits at channel 1.</p>
                 </div>
                 <div class="controlitemgroup" id="saveLoadShare">
                     <h3>Save/Load/Share</h3>


### PR DESCRIPTION
This patch enables Synthmata to receive DX7 voice SYSEX, giving a two-way-programmer. With that, changes made on a real DX7 (or any clone like the Dexed plugin ) could be send back into the UI, enabling the user to edit patches on the fly without having to dump them to a file and upload to Synthmata first.

This is somewhat incomplete, as a real DX7 would send "parameter change" SYSEX on every live change, however implementing these is quite complicated, as they use a different format than a voice dump.
So for now, after enabling SYSEX transmission on the DX7, the patch will be loaded to Synthmata only if the voice is switched by a button on the DX7. 
However, after loading the voice into Synthmatha one would most likely edit it there anywhere and don't use the DX7 menus anymore. 
So even with this caveat, this gives a usable DX7 programmer experience.